### PR TITLE
fix(ci): apply cargo fmt to Phase 7 files (CI unblock)

### DIFF
--- a/crates/kay-cli/tests/context_e2e.rs
+++ b/crates/kay-cli/tests/context_e2e.rs
@@ -19,7 +19,10 @@ fn context_injected_into_system_prompt() {
     // Phase 7: _ctx_packet is assembled but not injected into OpenRouter request.
     // This test verifies the budget defaults are correct (Phase 8+ injects the packet).
     let budget = ContextBudget::default();
-    assert_eq!(budget.max_tokens, 8192, "default max_tokens should be 8192 (DL-7)");
+    assert_eq!(
+        budget.max_tokens, 8192,
+        "default max_tokens should be 8192 (DL-7)"
+    );
     assert_eq!(
         budget.reserve_tokens, 1024,
         "default reserve_tokens should be 1024 (DL-7)"

--- a/crates/kay-context/src/indexer.rs
+++ b/crates/kay-context/src/indexer.rs
@@ -49,11 +49,7 @@ impl TreeSitterIndexer {
 
         let should_skip = store.check_and_set_index_state(&file_path_str, &hash)?;
         if should_skip {
-            return Ok(IndexStats {
-                files: 1,
-                symbols: 0,
-                skipped_files: 1,
-            });
+            return Ok(IndexStats { files: 1, symbols: 0, skipped_files: 1 });
         }
 
         let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
@@ -71,11 +67,7 @@ impl TreeSitterIndexer {
             store.insert_symbol(&sym)?;
         }
 
-        Ok(IndexStats {
-            files: 1,
-            symbols: sym_count,
-            skipped_files: 0,
-        })
+        Ok(IndexStats { files: 1, symbols: sym_count, skipped_files: 0 })
     }
 
     fn extract_symbols(
@@ -146,12 +138,8 @@ impl TreeSitterIndexer {
                 continue;
             }
 
-            let start_line = def_node
-                .map(|n| n.start_position().row as u32)
-                .unwrap_or(0);
-            let end_line = def_node
-                .map(|n| n.end_position().row as u32)
-                .unwrap_or(0);
+            let start_line = def_node.map(|n| n.start_position().row as u32).unwrap_or(0);
+            let end_line = def_node.map(|n| n.end_position().row as u32).unwrap_or(0);
 
             let sig = def_node
                 .and_then(|n| n.utf8_text(source_bytes).ok())

--- a/crates/kay-context/src/retriever.rs
+++ b/crates/kay-context/src/retriever.rs
@@ -7,15 +7,15 @@ pub fn rrf_score(rank: usize) -> f64 {
 
 /// Apply name-bonus of +0.5 when query term exactly matches symbol name (DL-10).
 pub fn apply_name_bonus(score: f64, symbol_name: &str, query: &str) -> f64 {
-    if symbol_name == query { score + 0.5 } else { score }
+    if symbol_name == query {
+        score + 0.5
+    } else {
+        score
+    }
 }
 
 /// Merge FTS5 results and ANN results using RRF (DL-10).
-pub fn rrf_merge(
-    fts_results: Vec<Symbol>,
-    ann_results: Vec<Symbol>,
-    query: &str,
-) -> Vec<Symbol> {
+pub fn rrf_merge(fts_results: Vec<Symbol>, ann_results: Vec<Symbol>, query: &str) -> Vec<Symbol> {
     use std::collections::HashMap;
 
     // Map symbol id → cumulative RRF score + symbol
@@ -38,9 +38,13 @@ pub fn rrf_merge(
 pub struct Retriever;
 
 impl Retriever {
-    pub fn new() -> Self { Self }
+    pub fn new() -> Self {
+        Self
+    }
 }
 
 impl Default for Retriever {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }

--- a/crates/kay-context/src/store.rs
+++ b/crates/kay-context/src/store.rs
@@ -122,24 +122,13 @@ impl SymbolStore {
             ",
         )?;
 
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM schema_version",
-            [],
-            |r| r.get(0),
-        )?;
+        let count: i64 = conn.query_row("SELECT COUNT(*) FROM schema_version", [], |r| r.get(0))?;
         if count == 0 {
             conn.execute("INSERT INTO schema_version VALUES (1)", [])?;
         } else {
-            let v: i64 = conn.query_row(
-                "SELECT version FROM schema_version",
-                [],
-                |r| r.get(0),
-            )?;
+            let v: i64 = conn.query_row("SELECT version FROM schema_version", [], |r| r.get(0))?;
             if v != 1 {
-                return Err(ContextError::SchemaVersionMismatch {
-                    found: v as u32,
-                    expected: 1,
-                });
+                return Err(ContextError::SchemaVersionMismatch { found: v as u32, expected: 1 });
             }
         }
         Ok(())
@@ -277,11 +266,7 @@ impl SymbolStore {
     ///
     /// For FakeEmbedder / test use, all vectors are zero-vectors so every row
     /// ties at distance 0.0 and the result is non-empty as long as rows exist.
-    pub fn ann_search(
-        &self,
-        query_vec: &[f32],
-        limit: usize,
-    ) -> Result<Vec<Symbol>, ContextError> {
+    pub fn ann_search(&self, query_vec: &[f32], limit: usize) -> Result<Vec<Symbol>, ContextError> {
         // Collect all (symbol_id, embedding) rows.
         let mut stmt = self.conn.prepare(
             "SELECT sv.symbol_id, s.name, s.kind, s.file_path, s.start_line, s.end_line, s.sig, sv.embedding
@@ -299,32 +284,46 @@ impl SymbolStore {
                 let end_line: u32 = r.get(5)?;
                 let sig: String = r.get(6)?;
                 let embedding_json: String = r.get(7)?;
-                Ok((symbol_id, name, kind_str, file_path, start_line, end_line, sig, embedding_json))
-            })?
-            .filter_map(|r| r.ok())
-            .filter_map(|(sid, name, kind_str, file_path, start_line, end_line, sig, embedding_json)| {
-                let sym = Symbol {
-                    id: sid,
+                Ok((
+                    symbol_id,
                     name,
-                    kind: SymbolKind::from_kind_str(&kind_str),
+                    kind_str,
                     file_path,
                     start_line,
                     end_line,
                     sig,
-                };
-                // Deserialise embedding; skip corrupt rows rather than silently
-                // treating a parse failure as a zero-vector (which would make
-                // corrupt rows appear at maximum distance instead of being surfaced).
-                let embedding: Vec<f32> = match serde_json::from_str(&embedding_json) {
-                    Ok(v) => v,
-                    Err(_e) => {
-                        tracing::warn!(symbol_id = sym.id, "embedding parse failed; skipping row");
-                        return None; // filter_map drops this row
-                    }
-                };
-                let dist = l2_distance(query_vec, &embedding);
-                Some((dist, sym))
-            })
+                    embedding_json,
+                ))
+            })?
+            .filter_map(|r| r.ok())
+            .filter_map(
+                |(sid, name, kind_str, file_path, start_line, end_line, sig, embedding_json)| {
+                    let sym = Symbol {
+                        id: sid,
+                        name,
+                        kind: SymbolKind::from_kind_str(&kind_str),
+                        file_path,
+                        start_line,
+                        end_line,
+                        sig,
+                    };
+                    // Deserialise embedding; skip corrupt rows rather than silently
+                    // treating a parse failure as a zero-vector (which would make
+                    // corrupt rows appear at maximum distance instead of being surfaced).
+                    let embedding: Vec<f32> = match serde_json::from_str(&embedding_json) {
+                        Ok(v) => v,
+                        Err(_e) => {
+                            tracing::warn!(
+                                symbol_id = sym.id,
+                                "embedding parse failed; skipping row"
+                            );
+                            return None; // filter_map drops this row
+                        }
+                    };
+                    let dist = l2_distance(query_vec, &embedding);
+                    Some((dist, sym))
+                },
+            )
             .collect();
 
         candidates.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
@@ -352,7 +351,8 @@ impl SymbolStore {
                 sig: r.get(6)?,
             })
         })?;
-        rows.collect::<Result<Vec<_>, _>>().map_err(ContextError::from)
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(ContextError::from)
     }
 }
 

--- a/crates/kay-context/src/watcher.rs
+++ b/crates/kay-context/src/watcher.rs
@@ -1,5 +1,5 @@
 use crate::error::ContextError;
-use notify_debouncer_mini::{new_debouncer, DebouncedEventKind, DebounceEventResult};
+use notify_debouncer_mini::{DebounceEventResult, DebouncedEventKind, new_debouncer};
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -49,19 +49,17 @@ impl FileWatcher {
                     ) && is_source_file(&e.path)
                         && !should_ignore(&e.path)
                 });
-                if triggered { callback(); }
+                if triggered {
+                    callback();
+                }
             },
         )
-        .map_err(|e| {
-            std::io::Error::other(format!("notify debouncer init: {e}"))
-        })?;
+        .map_err(|e| std::io::Error::other(format!("notify debouncer init: {e}")))?;
 
         debouncer
             .watcher()
             .watch(root, notify::RecursiveMode::Recursive)
-            .map_err(|e| {
-                std::io::Error::other(format!("notify watch: {e}"))
-            })?;
+            .map_err(|e| std::io::Error::other(format!("notify watch: {e}")))?;
 
         Ok(Self { _watcher: debouncer })
     }
@@ -87,7 +85,12 @@ fn should_ignore(path: &std::path::Path) -> bool {
     if IGNORED_SEGMENTS.iter().any(|seg| path_str.contains(seg)) {
         return true;
     }
-    if path.extension().and_then(|e| e.to_str()).map(|ext| IGNORED_EXTS.contains(&ext)).unwrap_or(false) {
+    if path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|ext| IGNORED_EXTS.contains(&ext))
+        .unwrap_or(false)
+    {
         return true;
     }
     false

--- a/crates/kay-context/tests/budget.rs
+++ b/crates/kay-context/tests/budget.rs
@@ -46,7 +46,10 @@ fn one_over_truncates() {
     let symbols = vec![make_symbol("foo", "fn foo() -> i32")]; // estimate=7
     let packet = budget.assemble(symbols, &[]);
     assert_eq!(packet.dropped_symbols, 1, "should drop 1 symbol");
-    assert!(packet.symbols.is_empty(), "no symbol should fit in 6 tokens");
+    assert!(
+        packet.symbols.is_empty(),
+        "no symbol should fit in 6 tokens"
+    );
 }
 
 #[test]

--- a/crates/kay-context/tests/hardener.rs
+++ b/crates/kay-context/tests/hardener.rs
@@ -1,5 +1,5 @@
-use kay_context::hardener::SchemaHardener;
 use kay_context::engine::{ContextEngine, NoOpContextEngine};
+use kay_context::hardener::SchemaHardener;
 use serde_json::json;
 
 fn make_schema(with_properties_first: bool) -> serde_json::Value {
@@ -32,17 +32,25 @@ fn harden_moves_required_before_properties() {
     let hardener = SchemaHardener::default();
     let mut schema = make_schema(true); // properties BEFORE required (input order)
     hardener.harden(&mut schema);
-    let obj = schema.as_object().expect("hardened schema should be an object");
+    let obj = schema
+        .as_object()
+        .expect("hardened schema should be an object");
     // required must be present after hardening
-    let required = obj.get("required").expect("required should be present after hardening");
+    let required = obj
+        .get("required")
+        .expect("required should be present after hardening");
     let required_arr = required.as_array().expect("required should be an array");
     // "input" property must appear in required
     assert!(
         required_arr.iter().any(|v| v.as_str() == Some("input")),
-        "required should contain 'input' after hardening, got: {:?}", required_arr
+        "required should contain 'input' after hardening, got: {:?}",
+        required_arr
     );
     // properties must still be present
-    assert!(obj.contains_key("properties"), "properties key must still be present");
+    assert!(
+        obj.contains_key("properties"),
+        "properties key must still be present"
+    );
     // additionalProperties: false must be set (strict mode)
     assert_eq!(
         obj.get("additionalProperties"),
@@ -74,7 +82,10 @@ fn harden_adds_truncation_reminder() {
     // After hardening, the schema should have a truncation reminder
     // (from TruncationHints) — just verify it's still a valid JSON object
     let hardened_str = serde_json::to_string(&schema).unwrap();
-    assert!(hardened_str.contains("type"), "hardened schema should still be valid JSON object");
+    assert!(
+        hardened_str.contains("type"),
+        "hardened schema should still be valid JSON object"
+    );
 }
 
 #[tokio::test]
@@ -92,11 +103,11 @@ async fn noop_engine_hardens_schemas() {
 
 #[test]
 fn tool_registry_schemas_method() {
-    use kay_tools::registry::ToolRegistry;
+    use forge_domain::{ToolName, ToolOutput};
     use kay_tools::contract::Tool;
     use kay_tools::error::ToolError;
+    use kay_tools::registry::ToolRegistry;
     use kay_tools::runtime::context::ToolCallContext;
-    use forge_domain::{ToolName, ToolOutput};
     use serde_json::Value;
     use std::sync::Arc;
 
@@ -106,8 +117,12 @@ fn tool_registry_schemas_method() {
 
     #[async_trait::async_trait]
     impl Tool for TestTool {
-        fn name(&self) -> &ToolName { &self.name }
-        fn description(&self) -> &str { "test tool" }
+        fn name(&self) -> &ToolName {
+            &self.name
+        }
+        fn description(&self) -> &str {
+            "test tool"
+        }
         fn input_schema(&self) -> Value {
             json!({
                 "type": "object",
@@ -130,12 +145,19 @@ fn tool_registry_schemas_method() {
     // Empty registry returns empty vec
     let registry = ToolRegistry::new();
     let schemas = registry.schemas();
-    assert!(schemas.is_empty(), "empty registry should return empty schemas vec");
+    assert!(
+        schemas.is_empty(),
+        "empty registry should return empty schemas vec"
+    );
 
     // Registry with a tool returns its schema
     let mut registry2 = ToolRegistry::new();
     registry2.register(Arc::new(TestTool { name: ToolName::new("test-tool") }));
     let schemas2 = registry2.schemas();
-    assert_eq!(schemas2.len(), 1, "registry with 1 tool should return 1 schema");
+    assert_eq!(
+        schemas2.len(),
+        1,
+        "registry with 1 tool should return 1 schema"
+    );
     assert!(schemas2[0].is_object(), "schema should be a JSON object");
 }

--- a/crates/kay-context/tests/indexer.rs
+++ b/crates/kay-context/tests/indexer.rs
@@ -1,8 +1,8 @@
 use kay_context::indexer::TreeSitterIndexer;
 use kay_context::language::Language;
 use kay_context::store::{Symbol, SymbolKind, SymbolStore};
-use tempfile::TempDir;
 use std::path::Path;
+use tempfile::TempDir;
 
 fn make_store() -> (SymbolStore, TempDir) {
     let dir = TempDir::new().unwrap();
@@ -24,8 +24,13 @@ async fn rust_fn_extracted() {
     let stats = indexer.index_file(&src, &store).await.unwrap();
     assert!(stats.symbols >= 1);
     let results = store.search_fts("foo", 10).unwrap();
-    assert!(results.iter().any(|s| s.name == "foo" && s.kind == SymbolKind::Function),
-        "expected fn foo, got: {:?}", results);
+    assert!(
+        results
+            .iter()
+            .any(|s| s.name == "foo" && s.kind == SymbolKind::Function),
+        "expected fn foo, got: {:?}",
+        results
+    );
 }
 
 #[tokio::test]
@@ -35,8 +40,13 @@ async fn rust_trait_extracted() {
     let indexer = TreeSitterIndexer::new();
     indexer.index_file(&src, &store).await.unwrap();
     let results = store.search_fts("Bar", 10).unwrap();
-    assert!(results.iter().any(|s| s.name == "Bar" && s.kind == SymbolKind::Trait),
-        "expected trait Bar, got: {:?}", results);
+    assert!(
+        results
+            .iter()
+            .any(|s| s.name == "Bar" && s.kind == SymbolKind::Trait),
+        "expected trait Bar, got: {:?}",
+        results
+    );
 }
 
 #[tokio::test]
@@ -46,15 +56,23 @@ async fn rust_mod_boundary() {
     let indexer = TreeSitterIndexer::new();
     indexer.index_file(&src, &store).await.unwrap();
     let results = store.search_fts("utils", 10).unwrap();
-    assert!(results.iter().any(|s| s.name == "utils" && s.kind == SymbolKind::Module),
-        "expected mod utils, got: {:?}", results);
+    assert!(
+        results
+            .iter()
+            .any(|s| s.name == "utils" && s.kind == SymbolKind::Module),
+        "expected mod utils, got: {:?}",
+        results
+    );
 }
 
 #[tokio::test]
 async fn typescript_function_extracted() {
     let (store, dir) = make_store();
-    let src = write_file(dir.path(), "x.ts",
-        "function greet(name: string): string { return name; }\n");
+    let src = write_file(
+        dir.path(),
+        "x.ts",
+        "function greet(name: string): string { return name; }\n",
+    );
     let indexer = TreeSitterIndexer::new();
     indexer.index_file(&src, &store).await.unwrap();
     let results = store.search_fts("greet", 10).unwrap();
@@ -74,8 +92,7 @@ async fn typescript_class_extracted() {
 #[tokio::test]
 async fn python_def_extracted() {
     let (store, dir) = make_store();
-    let src = write_file(dir.path(), "p.py",
-        "def compute(x):\n    return x * 2\n");
+    let src = write_file(dir.path(), "p.py", "def compute(x):\n    return x * 2\n");
     let indexer = TreeSitterIndexer::new();
     indexer.index_file(&src, &store).await.unwrap();
     let results = store.search_fts("compute", 10).unwrap();
@@ -95,8 +112,11 @@ async fn python_class_extracted() {
 #[tokio::test]
 async fn go_func_extracted() {
     let (store, dir) = make_store();
-    let src = write_file(dir.path(), "g.go",
-        "package main\nfunc Run(ctx interface{}) error { return nil }\n");
+    let src = write_file(
+        dir.path(),
+        "g.go",
+        "package main\nfunc Run(ctx interface{}) error { return nil }\n",
+    );
     let indexer = TreeSitterIndexer::new();
     indexer.index_file(&src, &store).await.unwrap();
     let results = store.search_fts("Run", 10).unwrap();
@@ -115,7 +135,11 @@ async fn sig_truncated_at_256() {
     let results = store.search_fts("long_fn", 10).unwrap();
     assert!(!results.is_empty(), "expected long_fn");
     let sig = &results[0].sig;
-    assert!(sig.chars().count() <= 257, "sig too long: {} chars", sig.chars().count());
+    assert!(
+        sig.chars().count() <= 257,
+        "sig too long: {} chars",
+        sig.chars().count()
+    );
     if sig.chars().count() == 257 {
         assert!(sig.ends_with('…'), "truncated sig should end with ellipsis");
     }
@@ -124,13 +148,22 @@ async fn sig_truncated_at_256() {
 #[tokio::test]
 async fn unknown_extension_file_boundary() {
     let (store, dir) = make_store();
-    let src = write_file(dir.path(), "config.toml",
-        "[package]\nname = \"test\"\nversion = \"0.1.0\"\n[dependencies]\n");
+    let src = write_file(
+        dir.path(),
+        "config.toml",
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"\n[dependencies]\n",
+    );
     let indexer = TreeSitterIndexer::new();
     let stats = indexer.index_file(&src, &store).await.unwrap();
-    assert_eq!(stats.symbols, 1, "should produce exactly 1 FileBoundary symbol");
+    assert_eq!(
+        stats.symbols, 1,
+        "should produce exactly 1 FileBoundary symbol"
+    );
     let results = store.search_fts("package", 10).unwrap();
-    assert!(!results.is_empty(), "FileBoundary symbol should contain first 10 lines");
+    assert!(
+        !results.is_empty(),
+        "FileBoundary symbol should contain first 10 lines"
+    );
     assert_eq!(results[0].kind, SymbolKind::FileBoundary);
 }
 

--- a/crates/kay-context/tests/retriever_fts.rs
+++ b/crates/kay-context/tests/retriever_fts.rs
@@ -1,5 +1,5 @@
+use kay_context::retriever::{apply_name_bonus, rrf_merge, rrf_score};
 use kay_context::store::{Symbol, SymbolKind, SymbolStore};
-use kay_context::retriever::{rrf_merge, rrf_score, apply_name_bonus};
 use tempfile::TempDir;
 
 fn make_store() -> (SymbolStore, TempDir) {
@@ -9,14 +9,17 @@ fn make_store() -> (SymbolStore, TempDir) {
 }
 
 fn insert_sym(store: &SymbolStore, name: &str, sig: &str, file: &str) {
-    store.insert_symbol(&Symbol {
-        id: 0,
-        name: name.to_string(),
-        kind: SymbolKind::Function,
-        file_path: file.to_string(),
-        start_line: 1, end_line: 2,
-        sig: sig.to_string(),
-    }).unwrap();
+    store
+        .insert_symbol(&Symbol {
+            id: 0,
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            file_path: file.to_string(),
+            start_line: 1,
+            end_line: 2,
+            sig: sig.to_string(),
+        })
+        .unwrap();
 }
 
 #[test]
@@ -49,13 +52,19 @@ fn fts_prefix_match() {
 #[test]
 fn fts_name_bonus_applied() {
     // rrf_score + apply_name_bonus arithmetic
-    let base = rrf_score(0);  // 1/60
+    let base = rrf_score(0); // 1/60
     let with_bonus = apply_name_bonus(base, "query_term", "query_term");
     let without_bonus = apply_name_bonus(base, "other_name", "query_term");
-    assert!(with_bonus > without_bonus,
-        "exact name match should have higher score: {} vs {}", with_bonus, without_bonus);
-    assert!((with_bonus - base - 0.5).abs() < f64::EPSILON,
-        "name bonus should be exactly +0.5");
+    assert!(
+        with_bonus > without_bonus,
+        "exact name match should have higher score: {} vs {}",
+        with_bonus,
+        without_bonus
+    );
+    assert!(
+        (with_bonus - base - 0.5).abs() < f64::EPSILON,
+        "name bonus should be exactly +0.5"
+    );
 }
 
 #[test]
@@ -67,18 +76,27 @@ fn fts_ranking_order() {
     let results = store.search_fts("foo", 10).unwrap();
     assert!(!results.is_empty());
     // heavy has more occurrences, should rank first
-    assert_eq!(results[0].name, "foo_heavy",
-        "symbol with more query occurrences should rank first");
+    assert_eq!(
+        results[0].name, "foo_heavy",
+        "symbol with more query occurrences should rank first"
+    );
 }
 
 #[test]
 fn fts_multi_word_query() {
     let (store, _dir) = make_store();
-    insert_sym(&store, "run_loop_fn", "fn run_loop_fn() // run and loop", "a.rs");
+    insert_sym(
+        &store,
+        "run_loop_fn",
+        "fn run_loop_fn() // run and loop",
+        "a.rs",
+    );
     insert_sym(&store, "only_run", "fn only_run()", "b.rs");
     // FTS5 multi-word: both tokens must match
     let results = store.search_fts("run loop", 10).unwrap();
     // run_loop_fn has both "run" and "loop", only_run has only "run"
-    assert!(results.iter().any(|s| s.name == "run_loop_fn"),
-        "multi-token query should match symbol containing both tokens");
+    assert!(
+        results.iter().any(|s| s.name == "run_loop_fn"),
+        "multi-token query should match symbol containing both tokens"
+    );
 }

--- a/crates/kay-context/tests/retriever_vec.rs
+++ b/crates/kay-context/tests/retriever_vec.rs
@@ -1,6 +1,6 @@
-use kay_context::store::{Symbol, SymbolKind, SymbolStore};
 use kay_context::embedder::FakeEmbedder;
 use kay_context::retriever::rrf_merge;
+use kay_context::store::{Symbol, SymbolKind, SymbolStore};
 use tempfile::TempDir;
 
 fn make_store() -> (SymbolStore, TempDir) {
@@ -15,7 +15,8 @@ fn make_sym(id: i64, name: &str) -> Symbol {
         name: name.to_string(),
         kind: SymbolKind::Function,
         file_path: "a.rs".to_string(),
-        start_line: 1, end_line: 2,
+        start_line: 1,
+        end_line: 2,
         sig: format!("fn {}()", name),
     }
 }
@@ -26,10 +27,14 @@ async fn vec_table_created_with_fake_embedder() {
     let embedder = FakeEmbedder { dimensions: 4 };
     store.enable_vector_search(&embedder, 4).unwrap();
     // symbols_vec table should exist
-    let count: i64 = store.conn.query_row(
-        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='symbols_vec'",
-        [], |r| r.get(0)
-    ).unwrap();
+    let count: i64 = store
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='symbols_vec'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
     assert_eq!(count, 1, "symbols_vec table should be created");
 }
 
@@ -44,9 +49,11 @@ async fn fake_embedder_insert_and_ann() {
         let sym = make_sym(i + 1, &format!("fn_{}", i));
         store.insert_symbol(&sym).unwrap();
         let vec = embedder.embed_sync(&sym.sig);
-        store.upsert_vector(sym.id.max(1), &vec).unwrap_or_else(|_| {
-            // id may be auto-assigned; re-query
-        });
+        store
+            .upsert_vector(sym.id.max(1), &vec)
+            .unwrap_or_else(|_| {
+                // id may be auto-assigned; re-query
+            });
     }
     // ANN search with a zero-vector should return results
     let query_vec = vec![0.0f32; 4];
@@ -66,8 +73,11 @@ fn rrf_merge_prefers_fts_winner() {
     let merged = rrf_merge(fts_results, ann_results, "alpha_winner");
     assert!(!merged.is_empty());
     // With name-bonus of +0.5 on FTS for alpha_winner, A should rank first
-    assert_eq!(merged[0].name, "alpha_winner",
-        "FTS winner with name-bonus should rank first, got: {:?}", merged[0].name);
+    assert_eq!(
+        merged[0].name, "alpha_winner",
+        "FTS winner with name-bonus should rank first, got: {:?}",
+        merged[0].name
+    );
 }
 
 #[test]
@@ -81,8 +91,10 @@ fn rrf_merge_prefers_vec_winner() {
 
     let merged = rrf_merge(fts_results, ann_results, "unrelated_query");
     assert!(!merged.is_empty());
-    assert_eq!(merged[0].name, "vec_winner",
-        "ANN winner should rank first when no FTS signal");
+    assert_eq!(
+        merged[0].name, "vec_winner",
+        "ANN winner should rank first when no FTS signal"
+    );
 }
 
 #[test]
@@ -91,18 +103,28 @@ fn rrf_k60_score_formula() {
     use kay_context::retriever::rrf_score;
     let score_r0 = rrf_score(0);
     let expected_r0 = 1.0 / 60.0;
-    assert!((score_r0 - expected_r0).abs() < 1e-10,
-        "rrf_score(0) should be 1/60, got {}", score_r0);
+    assert!(
+        (score_r0 - expected_r0).abs() < 1e-10,
+        "rrf_score(0) should be 1/60, got {}",
+        score_r0
+    );
 
     let score_r1 = rrf_score(1);
     let expected_r1 = 1.0 / 61.0;
-    assert!((score_r1 - expected_r1).abs() < 1e-10,
-        "rrf_score(1) should be 1/61, got {}", score_r1);
+    assert!(
+        (score_r1 - expected_r1).abs() < 1e-10,
+        "rrf_score(1) should be 1/61, got {}",
+        score_r1
+    );
 
     // Verify symbol appearing in both lists gets both scores
     let sym = make_sym(1, "double_hit");
     let merged = rrf_merge(vec![sym.clone()], vec![sym.clone()], "x");
-    assert_eq!(merged.len(), 1, "same symbol from both lists → merged into 1");
+    assert_eq!(
+        merged.len(),
+        1,
+        "same symbol from both lists → merged into 1"
+    );
     // Score should be rrf_score(0) + rrf_score(0) = 1/60 + 1/60
 }
 

--- a/crates/kay-context/tests/store.rs
+++ b/crates/kay-context/tests/store.rs
@@ -17,10 +17,14 @@ fn schema_creates_tables() {
     ).unwrap();
     assert_eq!(count, 2);
     // Verify symbols_fts virtual table
-    let fts_count: i64 = store.conn.query_row(
-        "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='symbols_fts'",
-        [], |r| r.get(0)
-    ).unwrap();
+    let fts_count: i64 = store
+        .conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='symbols_fts'",
+            [],
+            |r| r.get(0),
+        )
+        .unwrap();
     assert_eq!(fts_count, 1);
 }
 
@@ -47,9 +51,13 @@ fn insert_and_query_by_name() {
 fn delete_clears_fts() {
     let (store, _dir) = open_temp();
     let sym = Symbol {
-        id: 0, name: "bar".to_string(), kind: SymbolKind::Struct,
+        id: 0,
+        name: "bar".to_string(),
+        kind: SymbolKind::Struct,
         file_path: "src/bar.rs".to_string(),
-        start_line: 1, end_line: 5, sig: "struct bar {}".to_string(),
+        start_line: 1,
+        end_line: 5,
+        sig: "struct bar {}".to_string(),
     };
     store.insert_symbol(&sym).unwrap();
     store.delete_file("src/bar.rs").unwrap();
@@ -72,18 +80,29 @@ fn index_state_skip_on_same_hash() {
 #[test]
 fn index_state_updates_on_hash_change() {
     let (store, _dir) = open_temp();
-    store.check_and_set_index_state("main.rs", "hash_v1").unwrap();
+    store
+        .check_and_set_index_state("main.rs", "hash_v1")
+        .unwrap();
     // Insert a symbol for this file
     let sym = Symbol {
-        id: 0, name: "old_fn".to_string(), kind: SymbolKind::Function,
+        id: 0,
+        name: "old_fn".to_string(),
+        kind: SymbolKind::Function,
         file_path: "main.rs".to_string(),
-        start_line: 1, end_line: 2, sig: "fn old_fn()".to_string(),
+        start_line: 1,
+        end_line: 2,
+        sig: "fn old_fn()".to_string(),
     };
     store.insert_symbol(&sym).unwrap();
     // Different hash — should NOT skip, and old symbols for file should be deleted
-    let should_skip = store.check_and_set_index_state("main.rs", "hash_v2").unwrap();
+    let should_skip = store
+        .check_and_set_index_state("main.rs", "hash_v2")
+        .unwrap();
     assert!(!should_skip, "should NOT skip when hash changes");
     // Verify old symbols were cleared (delete_file is called internally when hash changes)
     let results = store.search_fts("old_fn", 10).unwrap();
-    assert!(results.is_empty(), "old symbols should be cleared on hash change");
+    assert!(
+        results.is_empty(),
+        "old symbols should be cleared on hash change"
+    );
 }

--- a/crates/kay-context/tests/watcher.rs
+++ b/crates/kay-context/tests/watcher.rs
@@ -1,7 +1,7 @@
 use kay_context::watcher::FileWatcher;
 use std::sync::{
-    atomic::{AtomicUsize, Ordering},
     Arc,
+    atomic::{AtomicUsize, Ordering},
 };
 use std::time::Duration;
 use tempfile::TempDir;
@@ -11,8 +11,10 @@ async fn watcher_triggers_on_create() {
     let dir = TempDir::new().unwrap();
     let counter = Arc::new(AtomicUsize::new(0));
     let c = counter.clone();
-    let _watcher =
-        FileWatcher::new(dir.path(), move || { c.fetch_add(1, Ordering::SeqCst); }).unwrap();
+    let _watcher = FileWatcher::new(dir.path(), move || {
+        c.fetch_add(1, Ordering::SeqCst);
+    })
+    .unwrap();
 
     tokio::time::sleep(Duration::from_millis(100)).await; // let watcher settle
     std::fs::write(dir.path().join("new_file.rs"), "fn foo() {}").unwrap();
@@ -31,8 +33,10 @@ async fn watcher_triggers_on_modify() {
 
     let counter = Arc::new(AtomicUsize::new(0));
     let c = counter.clone();
-    let _watcher =
-        FileWatcher::new(dir.path(), move || { c.fetch_add(1, Ordering::SeqCst); }).unwrap();
+    let _watcher = FileWatcher::new(dir.path(), move || {
+        c.fetch_add(1, Ordering::SeqCst);
+    })
+    .unwrap();
 
     tokio::time::sleep(Duration::from_millis(100)).await;
     std::fs::write(&path, "fn modified() {}").unwrap();
@@ -51,8 +55,10 @@ async fn watcher_triggers_on_remove() {
 
     let counter = Arc::new(AtomicUsize::new(0));
     let c = counter.clone();
-    let _watcher =
-        FileWatcher::new(dir.path(), move || { c.fetch_add(1, Ordering::SeqCst); }).unwrap();
+    let _watcher = FileWatcher::new(dir.path(), move || {
+        c.fetch_add(1, Ordering::SeqCst);
+    })
+    .unwrap();
 
     tokio::time::sleep(Duration::from_millis(100)).await;
     std::fs::remove_file(&path).unwrap();
@@ -68,8 +74,10 @@ async fn watcher_ignores_non_source() {
     let dir = TempDir::new().unwrap();
     let counter = Arc::new(AtomicUsize::new(0));
     let c = counter.clone();
-    let _watcher =
-        FileWatcher::new(dir.path(), move || { c.fetch_add(1, Ordering::SeqCst); }).unwrap();
+    let _watcher = FileWatcher::new(dir.path(), move || {
+        c.fetch_add(1, Ordering::SeqCst);
+    })
+    .unwrap();
 
     tokio::time::sleep(Duration::from_millis(100)).await;
     std::fs::write(dir.path().join("Cargo.lock"), "# lock file").unwrap();
@@ -86,8 +94,10 @@ async fn watcher_debounce_coalesces_events() {
     let dir = TempDir::new().unwrap();
     let counter = Arc::new(AtomicUsize::new(0));
     let c = counter.clone();
-    let _watcher =
-        FileWatcher::new(dir.path(), move || { c.fetch_add(1, Ordering::SeqCst); }).unwrap();
+    let _watcher = FileWatcher::new(dir.path(), move || {
+        c.fetch_add(1, Ordering::SeqCst);
+    })
+    .unwrap();
 
     tokio::time::sleep(Duration::from_millis(100)).await;
     // Write 3 times within 100ms window — should coalesce to 1 event

--- a/crates/kay-tools/src/events.rs
+++ b/crates/kay-tools/src/events.rs
@@ -164,10 +164,7 @@ pub enum AgentEvent {
     /// is the count of files processed so far; `total` is the total file
     /// count in the watch scope. Consumers may use this to render a progress
     /// bar. Final emission has `indexed == total`.
-    IndexProgress {
-        indexed: usize,
-        total: usize,
-    },
+    IndexProgress { indexed: usize, total: usize },
 }
 
 /// A single streamed output frame from a tool. Phase 3 SHELL-03.


### PR DESCRIPTION
## Summary

- Fixes CI failure on `main` after Phase 7 merge (run [#24762421041](https://github.com/alo-exp/kay/actions/runs/24762421041))
- Root cause: `cargo fmt` stable (CI) formats differently from local nightly in 13 files — long `assert_eq!` calls, struct variant inline form, multi-arg function signatures
- Zero code logic changes — formatting only

## Files reformatted

All 13 files in `crates/kay-context/` (src + tests) and `crates/kay-tools/src/events.rs`.

## Verification

`cargo fmt --all -- --check` → 0 diffs after this patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
## Spec Traceability (auto-generated by Silver Bullet)
- Spec: .planning/SPEC.md (v1)
- JIRA: n/a
- Requirements covered: see SPEC.md ## Acceptance Criteria

### Deferred items (WARN findings from silver-validate)
```
FINDING [WARN] VAL-002: Assumption requires follow-up before implementation
FINDING [WARN] VAL-003: Assumption requires follow-up before implementation
FINDING [WARN] VAL-004: Assumption requires follow-up before implementation
FINDING [WARN] VAL-008: Open question unresolved
FINDING [WARN] VAL-009: Open question unresolved
FINDING [WARN] VAL-010: Open question unresolved
FINDING [WARN] VAL-011: Open question unresolved
FINDING [WARN] VAL-012: Open question unresolved
```