### PR TITLE
fix(ci): downgrade sqlite-vec to =0.1.9, fix clippy errors in kay-context tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7253,9 +7253,9 @@ dependencies = [
 
 [[package]]
 name = "sqlite-vec"
-version = "0.1.10-alpha.3"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b89e325282d9d05a53c7e5510b886d9510059c2b854c9606d07652549686f1"
+checksum = "d0ba424237a9a5db2f6071f193319e2b6a32f7f3961debb2fbbfe67067abce3f"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ tree-sitter-rust      = "0.23"
 tree-sitter-typescript = "0.23"
 tree-sitter-python    = "0.23"
 tree-sitter-go        = "0.23"
-sqlite-vec            = "=0.1.10-alpha.3"
+sqlite-vec            = "=0.1.9"
 notify                = "6.1"
 notify-debouncer-mini = "0.4"
 

--- a/crates/kay-context/tests/budget.rs
+++ b/crates/kay-context/tests/budget.rs
@@ -1,4 +1,4 @@
-use kay_context::budget::{ContextBudget, ContextPacket, estimate_tokens};
+use kay_context::budget::{ContextBudget, estimate_tokens};
 use kay_context::store::{Symbol, SymbolKind};
 
 fn make_symbol(name: &str, sig: &str) -> Symbol {

--- a/crates/kay-context/tests/hardener.rs
+++ b/crates/kay-context/tests/hardener.rs
@@ -29,7 +29,7 @@ fn harden_moves_required_before_properties() {
     // invariant is a logical guarantee, not a key-ordering guarantee).
     // serde_json without preserve_order uses BTreeMap (alphabetical keys), so
     // we verify the semantic contract: required exists and contains all props.
-    let hardener = SchemaHardener::default();
+    let hardener = SchemaHardener;
     let mut schema = make_schema(true); // properties BEFORE required (input order)
     hardener.harden(&mut schema);
     let obj = schema
@@ -61,7 +61,7 @@ fn harden_moves_required_before_properties() {
 
 #[test]
 fn harden_is_idempotent() {
-    let hardener = SchemaHardener::default();
+    let hardener = SchemaHardener;
     let mut schema = make_schema(true);
     hardener.harden(&mut schema);
     let once = schema.clone();
@@ -76,7 +76,7 @@ fn harden_is_idempotent() {
 
 #[test]
 fn harden_adds_truncation_reminder() {
-    let hardener = SchemaHardener::default();
+    let hardener = SchemaHardener;
     let mut schema = make_schema(false);
     hardener.harden(&mut schema);
     // After hardening, the schema should have a truncation reminder
@@ -92,7 +92,7 @@ fn harden_adds_truncation_reminder() {
 async fn noop_engine_hardens_schemas() {
     // NoOpContextEngine::retrieve must return a ContextPacket
     // The schemas parameter is passed through (Phase 7 only assembles ContextPacket)
-    let engine = NoOpContextEngine::default();
+    let engine = NoOpContextEngine;
     let schemas = vec![make_schema(false)];
     let packet = engine.retrieve("query", &schemas).await.unwrap();
     // NoOp returns empty symbols but the call must succeed

--- a/crates/kay-context/tests/indexer.rs
+++ b/crates/kay-context/tests/indexer.rs
@@ -1,6 +1,5 @@
 use kay_context::indexer::TreeSitterIndexer;
-use kay_context::language::Language;
-use kay_context::store::{Symbol, SymbolKind, SymbolStore};
+use kay_context::store::{SymbolKind, SymbolStore};
 use std::path::Path;
 use tempfile::TempDir;
 

--- a/crates/kay-context/tests/retriever_fts.rs
+++ b/crates/kay-context/tests/retriever_fts.rs
@@ -1,4 +1,4 @@
-use kay_context::retriever::{apply_name_bonus, rrf_merge, rrf_score};
+use kay_context::retriever::{apply_name_bonus, rrf_score};
 use kay_context::store::{Symbol, SymbolKind, SymbolStore};
 use tempfile::TempDir;
 

--- a/crates/kay-context/tests/retriever_vec.rs
+++ b/crates/kay-context/tests/retriever_vec.rs
@@ -49,11 +49,7 @@ async fn fake_embedder_insert_and_ann() {
         let sym = make_sym(i + 1, &format!("fn_{}", i));
         store.insert_symbol(&sym).unwrap();
         let vec = embedder.embed_sync(&sym.sig);
-        store
-            .upsert_vector(sym.id.max(1), &vec)
-            .unwrap_or_else(|_| {
-                // id may be auto-assigned; re-query
-            });
+        let _ = store.upsert_vector(sym.id.max(1), &vec);
     }
     // ANN search with a zero-vector should return results
     let query_vec = vec![0.0f32; 4];
@@ -130,10 +126,9 @@ fn rrf_k60_score_formula() {
 
 #[test]
 fn noop_embedder_skips_vec() {
-    use kay_context::embedder::NoOpEmbedder;
     use kay_context::engine::{ContextEngine, NoOpContextEngine};
 
-    let engine = NoOpContextEngine::default();
+    let engine = NoOpContextEngine;
     // NoOpContextEngine::retrieve must complete without accessing symbols_vec
     // (which doesn't exist in this test store)
     let rt = tokio::runtime::Runtime::new().unwrap();


### PR DESCRIPTION
## Summary

- **sqlite-vec =0.1.10-alpha.3 → =0.1.9**: The alpha.3 package is missing `sqlite-vec-diskann.c` on Linux CI, causing build failures. The vec API is not directly imported in any source file (pure Rust L2 + JSON storage), so the downgrade requires no code changes.
- **clippy::default_constructed_unit_structs**: `SchemaHardener::default()` → `SchemaHardener`, `NoOpContextEngine::default()` → `NoOpContextEngine` in test files.
- **Unused imports**: Removed `ContextPacket`, `rrf_merge`, `Language`, `Symbol`, `NoOpEmbedder` from test files where they were never used.

## Test plan

- [ ] `cargo clippy -p kay-context --tests -- -D warnings` → clean
- [ ] `cargo test -p kay-context` → all pass
- [ ] CI green on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---
## Spec Traceability (auto-generated by Silver Bullet)
- Spec: .planning/SPEC.md (v1)
- JIRA: n/a
- Requirements covered: see SPEC.md ## Acceptance Criteria

### Deferred items (WARN findings from silver-validate)
```
FINDING [WARN] VAL-002: Assumption requires follow-up before implementation
FINDING [WARN] VAL-003: Assumption requires follow-up before implementation
FINDING [WARN] VAL-004: Assumption requires follow-up before implementation
FINDING [WARN] VAL-008: Open question unresolved
FINDING [WARN] VAL-009: Open question unresolved
FINDING [WARN] VAL-010: Open question unresolved
FINDING [WARN] VAL-011: Open question unresolved
FINDING [WARN] VAL-012: Open question unresolved
```